### PR TITLE
Indent by four spaces rather than two

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,28 @@ conditionals.
 
 One loop construct:
   
-  while cond do
-    code
-  end
+    while cond do
+      code
+    end
 
 Conditionals:
 
-  if cond do
-    code
-  end
+    if cond do
+      code
+    end
 
-  if cond do
-    code
-  else
-    code'
-  end
+    if cond do
+      code
+    else
+      code'
+    end
 
 ### Memory
 
 4K bytes of word-addressable memory. Only data type is currently 32-bit integer,
 so use them as pointers as well:
 
-  x <- [address]
+    x <- [address]
 
 Only values 0..1023 will be valid addresses to access - crash and print a nice
 error message if out of range.
@@ -55,85 +55,85 @@ single integer to the console.
 
 ## Grammar
 
-  variable ::=
-      valid_name    // design later
+    variable ::=
+        valid_name    // design later
 
-  number ::= 
-      [0-9]+
-  
-  literal ::= 
-      '-' number 
-    | number
-  
-  factor ::=
-      literal
-    | variable
-    | '(' expr ')'  // parens
-    | '[' expr ']'  // deref
-    | call
+    number ::= 
+        [0-9]+
+    
+    literal ::= 
+        '-' number 
+      | number
+    
+    factor ::=
+        literal
+      | variable
+      | '(' expr ')'  // parens
+      | '[' expr ']'  // deref
+      | call
 
-  term ::=
-      factor
-    | factor '*' factor
-    | factor '/' factor
+    term ::=
+        factor
+      | factor '*' factor
+      | factor '/' factor
 
-  expr ::=
-      term
-    | term '+' term
-    | term '-' term
+    expr ::=
+        term
+      | term '+' term
+      | term '-' term
 
-  bool ::=
-      true
-    | false
-    | expr '=' expr
-    | expr '/=' expr
-    | expr '>' expr
-    | expr '<' expr
-    | expr '>=' expr
-    | expr '<=' expr
-    | bool 'and' bool
-    | bool 'or' bool
-    | 'not' bool
-    | '(' bool ')'
+    bool ::=
+        true
+      | false
+      | expr '=' expr
+      | expr '/=' expr
+      | expr '>' expr
+      | expr '<' expr
+      | expr '>=' expr
+      | expr '<=' expr
+      | bool 'and' bool
+      | bool 'or' bool
+      | 'not' bool
+      | '(' bool ')'
 
-  statement ::=
-      variable '<-' expr
-    | while
-    | if
+    statement ::=
+        variable '<-' expr
+      | while
+      | if
 
-  statements ::=
-      statement
-    | statement '\n' statements
+    statements ::=
+        statement
+      | statement '\n' statements
 
-  while ::=
-      'while' bool 'do\n' statements '\nend'
+    while ::=
+        'while' bool 'do\n' statements '\nend'
 
-  if ::=
-      'if' bool 'do\n' statements '\nend'
-    | 'if' bool 'then\n' statements '\nelse\n' statements '\nend'
+    if ::=
+        'if' bool 'do\n' statements '\nend'
+      | 'if' bool 'then\n' statements '\nelse\n' statements '\nend'
 
-  variables ::=
-      variable
-    | variable ',' variables
+    variables ::=
+        variable
+      | variable ',' variables
 
-  args ::=
-      '(' variables ')'
-    | '()'
+    args ::=
+        '(' variables ')'
+      | '()'
 
-  function ::=
-      'function' variable args '\n' statements '\n' end
+    function ::=
+        'function' variable args '\n' statements '\n' end
 
-  exprs ::=
-      expr
-    | expr ',' exprs
-    | '()'
+    exprs ::=
+        expr
+      | expr ',' exprs
+      | '()'
 
-  call ::=
-      variable '(' exprs ')'
+    call ::=
+        variable '(' exprs ')'
 
-  functions ::=
-      function
-    | function '\n' functions
+    functions ::=
+        function
+      | function '\n' functions
 
-  program ::=
-    functions '\n' statements
+    program ::=
+      functions '\n' statements


### PR DESCRIPTION
This fixes the formatting of the README.